### PR TITLE
v2 proposal

### DIFF
--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -95,6 +95,7 @@ Atom       = number
            | WhileExpr
            | LoopExpr
            | FnExpr
+           | TryExpr
            | '(' , Expression , ')' ;
 (*
   A <PairExpr> creates a value of type `Pair` given a <string> as the key and an
@@ -154,6 +155,11 @@ LoopExpr   = 'loop' , Block ;
   ```
 *)
 FnExpr     = 'fn' , identifier , ArgNames , Block ;
+(*
+  A <TryExpr> executes some block of code and catches any error that might occur.
+  The thrown error is then assigned to the <identifier> and the catch block is run.
+*)
+TryExpr    = 'try' , Block , 'catch' , identifier , Block ;
 
 Args     = '(' , [ Expression , { ',' , Expression } , [ ',' ] ] , ')' ;
 ArgNames = '(' , [ identifier , { ',' , identifier } , [ ',' ] ] , ')' ;

--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -62,7 +62,7 @@ BitXorExpr = BitAndExpr , { '^' , BitAndExpr } ;
 BitAndExpr = EqExpr , { '&' , EqExpr } ;
 EqExpr     = RelExpr , [ ( '==' | '!=' ) , RelExpr ] ;
 RelExpr    = ShiftExpr , [ ( '<' | '>' | '<=' | '>=' ) , ShiftExpr ] ;
-ShiftExpr  = AddExpr , [ ( '<<' | '>>' ) , AddExpr ] ;
+ShiftExpr  = AddExpr , { ( '<<' | '>>' ) , AddExpr } ;
 AddExpr    = MulExpr , { ( '+' | '-' ) , MulExpr } ;
 MulExpr    = CastExpr , { ( '*' | '/' | '%' ) , CastExpr } ;
 CastExpr   = UnaryExpr , [ 'as' , type ] ;

--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -17,10 +17,10 @@
 *)
 
 (*
-  Start symbol <Statements>:
-  Program consists of any amount of <Statement>s sepereated by semicolons
+  Start symbol:
+  Program consists of any amount of <Statement>s each followed by a ';'
 *)
-Statements = { Statement , ';' } ;
+Program = { Statement , ';' } ;
 
 (**************************)
 (******* STATEMENTS *******)
@@ -116,10 +116,10 @@ Atom       = number
 PairExpr   = string , '=>' , Expression ;
 (*
   A <Block> always creates a new scope for variables. It contains a sequence
-  of <Statement>s and returns the result of the optional <Expression> at the
-  end, or `null` otherwise.
+  of <Statement>s and returns the result of the one after the last semicolon,
+  or `null` otherwise.
 *)
-Block      = '{' , Statements , [ Expression ] , '}' ;
+Block      = '{' , [ Statement , { ';' , Statement } , [ ';' ] ] , '}' ;
 (*
   An <IfExpr> checks a condition and executes code based on whether that condition
   evaluates to `true` or `false`. The resulting value is the result of the executed

--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -72,7 +72,8 @@ EqExpr     = RelExpr , [ ( '==' | '!=' ) , RelExpr ] ;
 RelExpr    = ShiftExpr , [ ( '<' | '>' | '<=' | '>=' ) , ShiftExpr ] ;
 ShiftExpr  = AddExpr , [ ( '<<' | '>>' ) , AddExpr ] ;
 AddExpr    = MulExpr , { ( '+' | '-' ) , MulExpr } ;
-MulExpr    = UnaryExpr , { ( '*' | '/' | '%' ) , UnaryExpr } ;
+MulExpr    = CastExpr , { ( '*' | '/' | '%' ) , CastExpr } ;
+CastExpr   = UnaryExpr , [ 'as' , type ] ;
 UnaryExpr  = ( '+' | '-' | '!' ) , UnaryExpr
            | ExpExpr ;
 ExpExpr    = CallExpr , [ '**' , UnaryExpr ] ;
@@ -180,7 +181,8 @@ escape_seq  = '\' , ( ESCAPE_CHAR
                     | 'u' , 4 * HEX
                     | 'U' , 8 * HEX ) ;
 bool        = 'true' | 'false' | 'on' | 'off' ;
-identifier  = LETTER , { LETTER } ;
+type        = 'str' | 'bool' | 'num' | 'null' ;
+identifier  = ( LETTER , { LETTER } ) - ( bool | type | ? any keyword ? ) ;
 
 (************************************)
 (******* TERMINAL SYMBOL SETS *******)

--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -22,7 +22,9 @@
 *)
 Statements = { Statement , ';' } ;
 
-(* ----- STATEMENTS ----- *)
+(**************************)
+(******* STATEMENTS *******)
+(**************************)
 Statement    = LetStmt
              | BreakStmt
              | ContinueStmt
@@ -49,7 +51,9 @@ ContinueStmt = 'continue' ;
 *)
 ReturnStmt   = 'return' , [ Expression ] ;
 
-(* ----- EXPRESSIONS ----- *)
+(***************************)
+(******* EXPRESSIONS *******)
+(***************************)
 Expression = AssignExpr ;
 (*
   Assignments, defined by <AssignExpr>, mutate an existing value by assigning
@@ -164,7 +168,9 @@ TryExpr    = 'try' , Block , 'catch' , identifier , Block ;
 Args     = '(' , [ Expression , { ',' , Expression } , [ ',' ] ] , ')' ;
 ArgNames = '(' , [ identifier , { ',' , identifier } , [ ',' ] ] , ')' ;
 
-(* ----- NONTERMINAL TOKENS ----- *)
+(**********************************)
+(******* NONTERMINAL TOKENS *******)
+(**********************************)
 number      = DIGIT , { DIGIT } , [ '.' , DIGIT , { DIGIT } ] ;
 string      = '"' , { CHAR - ( '"' | '\' ) | escape_seq } , '"'
             | "'" , { CHAR - ( "'" | '\' ) | escape_seq } , "'" ;
@@ -176,7 +182,9 @@ escape_seq  = '\' , ( ESCAPE_CHAR
 bool        = 'true' | 'false' | 'on' | 'off' ;
 identifier  = LETTER , { LETTER } ;
 
-(* ----- TERMINAL SYMBOL SETS ----- *)
+(************************************)
+(******* TERMINAL SYMBOL SETS *******)
+(************************************)
 LETTER      = 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J'
             | 'K' | 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T'
             | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z'

--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -1,45 +1,187 @@
-Expressions = { eol } , [ Expression, { eol , { eol } , Expression } ] , { eol } ;
+(*
+  -- Grammar for Homescript --
 
-(* Expressions *)
-Expression  = AndExpr , { '||' , AndExpr } ;
-AndExpr     = EqExpr , { '&&' , EqExpr } ;
-EqExpr      = RelExpr , [ ( '==' | '!=' ) , RelExpr ] ;
-RelExpr     = NotExpr , [ ( '<' | '<=' | '>' | '>=' ) , NotExpr ] ;
-NotExpr     = [ '!' ] , Atom ;
-Atom        = number
-            | string
-            | bool
-            | identifier
-            | IfExpr
-            | CallExpr
-            | '(' , Expression , ')' ;
-IfExpr      = 'if' , Expression , '{' , Expressions , '}' , [ 'else' , '{' , Expressions , '}' ] ;
-CallExpr    = identifier , '(', { eol } , [ Expression , { ',' , { eol } , Expression } , [ ',' ] ] , { eol } , ')' ;
+  Author: RubixDev
+  Contributors:
 
-(* Tokens *)
-eol         = ? line break ? | ';' ;
+  This grammar is written in the EBNF notation defined by the ISO/IEC 14977 standard.
+  A lesser known feature of that standard is used here: the `{ ... }-` syntax
+  to describe a repetition of *one* or more times instead of the usual *zero* or more times
+  represented by `{ ... }`. This is actually just the exclusion (represented by the `-`) of
+  the empty sequence (because nothing follows the `-`) from the `{ ... }` repetition.
+
+  Whenever a symbol is referenced in a comment its name is enclosed in angle brackets (< and >).
+  The naming convention chosen here is PascalCase for context-free rules, snake_case for
+  regular rules, also known as nonterminals, and SCREAMING_SNAKE_CASE for sets of terminal
+  symbols.
+*)
+
+(*
+  Start symbol <Statements>:
+  Program consists of any amount of <Statement>s sepereated by semicolons
+*)
+Statements = [ Statement , { ';' , Statement } , [ ';' ] ] ;
+
+(* ----- STATEMENTS ----- *)
+Statement    = LetStmt
+             | BreakStmt
+             | ContinueStmt
+             | ReturnStmt
+             | Expression ;
+(*
+  A <LetStmt> is used to create new variables in the current scope. Variables propagate
+  up to inner scopes, but can be shadowed by declaring a new variable with the same name.
+  When no expression is provided, a value of `null` will be assigned to the new variable.
+*)
+LetStmt      = 'let' , identifier , [ '=' , Expression ] ;
+(*
+  A <BreakStmt> is used to stop a loop entirely. It can optionally be followed by an
+  expression that will be used as the loop's resulting value.
+*)
+BreakStmt    = 'break' , [ Expression ];
+(*
+  A <ContinueStmt> is used to skip to the next iteration of the current loop.
+*)
+ContinueStmt = 'continue' ;
+(*
+  A <ReturnStmt> is used to stop the currently running function. It can optionally be
+  followed by an expression that will be used as the function's return value.
+*)
+ReturnStmt   = 'return' , [ Expression ] ;
+
+(* ----- EXPRESSIONS ----- *)
+Expression = AssignExpr ;
+(*
+  Assignments, defined by <AssignExpr>, mutate an existing value by assigning
+  a new value to it. The new value is also the result of this expression.
+*)
+AssignExpr = identifier , ASSIGN_OPERATOR , Expression
+           | OrExpr ;
+ASSING_OPERATOR = '=' | '*=' | '/=' | '%=' | '+=' | '-=' | '<<=' | '>>='
+                | '&=' | '^=' | '|=' ;
+OrExpr     = AndExpr , { '||' , AndExpr } ;
+AndExpr    = BitOrExpr , { '&&' , BitOrExpr } ;
+BitOrExpr  = BitXorExpr , { '|' , BitXorExpr } ;
+BitXorExpr = BitAndExpr , { '^' , BitAndExpr } ;
+BitAndExpr = EqExpr , { '&' , EqExpr } ;
+EqExpr     = RelExpr , [ ( '==' | '!=' ) , RelExpr ] ;
+RelExpr    = ShiftExpr , [ ( '<' | '>' | '<=' | '>=' ) , ShiftExpr ] ;
+ShiftExpr  = AddExpr , [ ( '<<' | '>>' ) , AddExpr ] ;
+AddExpr    = MulExpr , { ( '+' | '-' ) , MulExpr } ;
+MulExpr    = UnaryExpr , { ( '*' | '/' | '%' ) , UnaryExpr } ;
+UnaryExpr  = ( '+' | '-' | '!' ) , UnaryExpr
+           | ExpExpr ;
+ExpExpr    = CallExpr , [ '**' , UnaryExpr ] ;
+(*
+  A <CallExpr> tries to call the given value as a function with supplied arguments.
+  The result is the return value of the called function.
+*)
+CallExpr   = MemberExpr , [ Args , { CallExprPart } ] ;
+(*
+  A <MemberExpr> accesses fields of a value. The only types that have fields are
+  `Pair` and `Time`.
+*)
+MemberExpr = Atom , { MemberExprPart } ;
+MemberExprPart = '.' , identifier ;
+CallExprPart   = MemberExprPart | Args ;
+Atom       = number
+           | bool
+           | string
+           | PairExpr (* <- also starts with <string>, but identifiable by the following `=>` *)
+           | 'null'
+           | identifier
+           | IfExpr
+           | ForExpr
+           | WhileExpr
+           | LoopExpr
+           | FnExpr
+           | '(' , Expression , ')' ;
+(*
+  A <PairExpr> creates a value of type `Pair` given a <string> as the key and an
+  arbitrary <Expression> for the value. `Pair`s are used in the builtin `exec` and
+  `http` functions. Additionaly, the key and value of a pair can be accessed through
+  the `k` and `v` fields respectively. An example might look like this:
+
+  ```
+  let my_pair = 'my_key' => 42;
+  assert(my_pair.k == 'my_key');
+  assert(my_pair.v == 42);
+  ```
+*)
+PairExpr   = string , '=>' , Expression ;
+(*
+  A <Block> always creates a new scope for variables. It contains a sequence
+  of <Statement>s and returns the result of the last one if that is not followed
+  by a semicolon, otherwise `null`.
+*)
+Block      = '{' , Statements , '}' ;
+(*
+  An <IfExpr> checks a condition and executes code based on whether that condition
+  evaluates to `true` or `false`. The resulting value is the result of the executed
+  <Block>, either the `if` or `else` block. When the condition evaluates to `false`
+  and no `else` <Block> is specified, the result will be `null`.
+*)
+IfExpr     = 'if' , Expression , Block , [ 'else' , ( IfExpr | Block ) ] ;
+(*
+  A <ForExpr> loops over the given (inclusive) range of numbers, assigning the current
+  number to the given <identifier> inside the <Block> for each iterations.
+  The resulting value is set by a <BreakStmt> inside the loop, or `null` if no
+  <BreakStmt> was encountered.
+*)
+ForExpr    = 'for' , identifier , 'in' , Expression , '..' , Expression , Block ;
+(*
+  A <WhileExpr> loops the given <Block> as long as the condition evaluates to `true`.
+  The resulting value is set by a <BreakStmt> inside the loop, or `null` if no
+  <BreakStmt> was encountered.
+*)
+WhileExpr  = 'while' , Expression , Block ;
+(*
+  A <LoopExpr> loops the given <Block> forever.
+  The resulting value is set by a <BreakStmt> inside the loop, or `null` if no
+  <BreakStmt> was encountered.
+*)
+LoopExpr   = 'loop' , Block ;
+(*
+  An <FnExpr> creates a value of type `Function` that defines a block of code
+  to be called at a later point in the script. An example usage might look like
+  the following:
+
+  ```
+  let add_one = fn(x) {
+      x + 1
+  };
+  assert(add_one(3) == 4);
+  ```
+*)
+FnExpr     = 'fn' , identifier , ArgNames , Block ;
+
+Args     = '(' , [ Expression , { ',' , Expression } , [ ',' ] ] , ')' ;
+ArgNames = '(' , [ identifier , { ',' , identifier } , [ ',' ] ] , ')' ;
+
+(* ----- NONTERMINAL TOKENS ----- *)
 number      = DIGIT , { DIGIT } , [ '.' , DIGIT , { DIGIT } ] ;
-string      = '"' , { CHAR - '"' - '\' | escape_seq } , '"'
-            | "'" , { CHAR - "'" - '\' | escape_seq } , "'" ;
+string      = '"' , { CHAR - ( '"' | '\' ) | escape_seq } , '"'
+            | "'" , { CHAR - ( "'" | '\' ) | escape_seq } , "'" ;
 escape_seq  = '\' , ( ESCAPE_CHAR
-                    | OCTAL , OCTAL , OCTAL
-                    | 'x' , HEX , HEX
-                    | 'u' , HEX , HEX , HEX , HEX
-                    | 'U' , HEX , HEX , HEX , HEX , HEX , HEX , HEX , HEX ) ;
+                    | 3 * OCTAL
+                    | 'x' , 2 * HEX
+                    | 'u' , 4 * HEX
+                    | 'U' , 8 * HEX ) ;
 bool        = 'true' | 'false' | 'on' | 'off' ;
 identifier  = LETTER , { LETTER } ;
 
-(* Character lists *)
+(* ----- TERMINAL SYMBOL SETS ----- *)
 LETTER      = 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J'
             | 'K' | 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T'
-            | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z' | 'a' | 'b' | 'c' | 'd'
-            | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm' | 'n'
-            | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x'
-            | 'y' | 'z' ;
-DIGIT       = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' ;
+            | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z'
+            | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j'
+            | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't'
+            | 'u' | 'v' | 'w' | 'x' | 'y' | 'z'
+            | '_' ;
 OCTAL       = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' ;
-HEX         = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
+DIGIT       = OCTAL | '8' | '9' ;
+HEX         = DIGIT
             | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'a' | 'b' | 'c' | 'd'
             | 'e' | 'f' ;
-CHAR        = ? any UTF8 character ? ;
+CHAR        = ? any character included in the Unicode character set ? ;
 ESCAPE_CHAR = '\' | "'" | '"' | 'b' | 'n' | 'r' | 't' ;

--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -20,7 +20,7 @@
   Start symbol <Statements>:
   Program consists of any amount of <Statement>s sepereated by semicolons
 *)
-Statements = [ Statement , { ';' , Statement } , [ ';' ] ] ;
+Statements = { Statement , ';' } ;
 
 (* ----- STATEMENTS ----- *)
 Statement    = LetStmt
@@ -111,10 +111,10 @@ Atom       = number
 PairExpr   = string , '=>' , Expression ;
 (*
   A <Block> always creates a new scope for variables. It contains a sequence
-  of <Statement>s and returns the result of the last one if that is not followed
-  by a semicolon, otherwise `null`.
+  of <Statement>s and returns the result of the optional <Expression> at the
+  end, or `null` otherwise.
 *)
-Block      = '{' , Statements , '}' ;
+Block      = '{' , Statements , [ Expression ] , '}' ;
 (*
   An <IfExpr> checks a condition and executes code based on whether that condition
   evaluates to `true` or `false`. The resulting value is the result of the executed

--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -131,7 +131,17 @@ IfExpr     = 'if' , Expression , Block , [ 'else' , ( IfExpr | Block ) ] ;
   A <ForExpr> loops over the given (inclusive) range of numbers, assigning the current
   number to the given <identifier> inside the <Block> for each iterations.
   The resulting value is set by a <BreakStmt> inside the loop, or `null` if no
-  <BreakStmt> was encountered.
+  <BreakStmt> was encountered. An example might look like the following:
+
+  ```
+  for i in 3..5 {
+      print(i);
+  };
+  # output:
+  # 3
+  # 4
+  # 5
+  ```
 *)
 ForExpr    = 'for' , identifier , 'in' , Expression , '..' , Expression , Block ;
 (*

--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -55,14 +55,6 @@ ReturnStmt   = 'return' , [ Expression ] ;
 (******* EXPRESSIONS *******)
 (***************************)
 Expression = AssignExpr ;
-(*
-  Assignments, defined by <AssignExpr>, mutate an existing value by assigning
-  a new value to it. The new value is also the result of this expression.
-*)
-AssignExpr = identifier , ASSIGN_OPERATOR , Expression
-           | OrExpr ;
-ASSING_OPERATOR = '=' | '*=' | '/=' | '%=' | '+=' | '-=' | '<<=' | '>>='
-                | '&=' | '^=' | '|=' ;
 OrExpr     = AndExpr , { '||' , AndExpr } ;
 AndExpr    = BitOrExpr , { '&&' , BitOrExpr } ;
 BitOrExpr  = BitXorExpr , { '|' , BitXorExpr } ;
@@ -76,7 +68,14 @@ MulExpr    = CastExpr , { ( '*' | '/' | '%' ) , CastExpr } ;
 CastExpr   = UnaryExpr , [ 'as' , type ] ;
 UnaryExpr  = ( '+' | '-' | '!' ) , UnaryExpr
            | ExpExpr ;
-ExpExpr    = CallExpr , [ '**' , UnaryExpr ] ;
+ExpExpr    = AssignExpr , [ '**' , UnaryExpr ] ;
+(*
+  Assignments, defined by <AssignExpr>, mutate an existing value by assigning
+  a new value to it. The new value is also the result of this expression.
+*)
+AssignExpr = CallExpr , [ ASSIGN_OPERATOR , Expression ] ;
+ASSING_OPERATOR = '=' | '*=' | '/=' | '%=' | '+=' | '-=' | '<<=' | '>>='
+                | '&=' | '^=' | '|=' | '**=' ;
 (*
   A <CallExpr> tries to call the given value as a function with supplied arguments.
   The result is the return value of the called function.


### PR DESCRIPTION
This is a proposal for a rewrite of Homescript with added features that we previously thought to be unnecessary. Mainly these include:
- loops
- custom functions
- custom variables
- a pair construction syntax: `'key' => 'value'`
- value members: `TIME.hour`

Currently only the grammar is rewritten to define the new syntax. Additionaly, newlines are now treated the same as spaces and have no syntactic meaning at all. Each statement must end with a semicolon and a block can optionally end with an expression.

Other proposed changes, that are not visible in the grammar file are:
- using snake_case instead of camelCase for function and variable names
- using SCREAMING_SNAKE_CASE for all builtin variables
- renaming the `checkArg()` function to `hasArg()`
- replacing the `getArg()` function with an `ARGS` global variable having each arg as a field, so an access like `getArg('myArg')` would instead look like `ARGS.myArg`
- the addition of an `assert()` function, that takes a boolean and panics with an "Assertion failed" message, in case the boolean is `false`

---

Other ideas that cloud be added to the proposal if wanted are:
- the `as` keyword to cast between different types, instead of having the `num()` and `str()` functions
- using a global `SWITCHES` variable for both querying and setting the switch states: `SWITCHES.s1 = on; assert(SWITCHES.s1 == on);`
- adding a try-catch block to allow catching errors at runtime:
```js
try {
    panic("error")
} catch e {
    assert(e == "error")
}
```

---

When this proposal gets accepted I recommend creating a new branch named `v2` or similar, editing this pull request to merge into that new branch instead of `main`, switching the state of this PR from draft to merge-ready, and merging it into the `v2` branch. Afterwards development on the changes can begin in the new branch